### PR TITLE
Include vmalloc.h file

### DIFF
--- a/one.c
+++ b/one.c
@@ -4,6 +4,7 @@
 #include <linux/module.h>
 #include <linux/fs.h>
 #include <linux/uaccess.h>
+#include <linux/vmalloc.h>
 
 MODULE_LICENSE("GPL");
 


### PR DESCRIPTION
If the header file is not added, I get an error at compile time:

```
/home/stephane/src/errsfs/c/dev_one/one.c: In function ‘device_file_read’:
/home/stephane/src/errsfs/c/dev_one/one.c:21:25: error: implicit declaration of function ‘vmalloc’; did you mean ‘d_alloc’? [-Werror=implicit-function-declaration]
   21 |     char* ptr = (char*) vmalloc(count);
      |                         ^~~~~~~
      |                         d_alloc
```

Tested with:

```
$ uname -r
5.15.0-1-amd64
$ lsb_release -a
No LSB modules are available.
Distributor ID:	Debian
Description:	Debian GNU/Linux bookworm/sid
Release:	testing
Codename:	bookworm
$ gcc --version
gcc (Debian 11.2.0-10) 11.2.0
```
