### PR TITLE
Rename creation command to fit README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ load:
 unload:
 	rmmod ./$(TARGET_MODULE).ko
 
-create:
+device:
 	mknod /dev/one c $(shell cat /proc/devices | grep one$ | cut -d ' ' -f1) 0
 
 delete:


### PR DESCRIPTION
The README file shows a `make device` command and Makefile has a `make create` command to do it.

This PR updates Makefile to have the same command in README and Makefile files.